### PR TITLE
update doxygen, and sphinx configuration files, 

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1861,7 +1861,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,13 +208,14 @@ htmlhelp_basename = 'DEploiddoc'
 
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+'papersize': 'letterpaper',
 
 # The font size ('10pt', '11pt' or '12pt').
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-#'preamble': '',
+'preamble': '\makeatletter\@openrightfalse',
+#'preamble': '\\renewcommand{\clearpage}{}',
 
 # Latex figure (float) alignment
 #'figure_align': 'htbp',
@@ -234,7 +235,7 @@ latex_documents = [
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+latex_use_parts = False
 
 # If true, show page references after internal links.
 #latex_show_pagerefs = False
@@ -284,3 +285,9 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+breathe_projects = {
+    "dEploid":"../xml/",
+    }
+
+extensions = [ "breathe" ]


### PR DESCRIPTION
now can produce manual in latex, man and html

first at root
```bash
doxygen Doxyfile
```

Then at `docs`
```bash
make man html latexpdf
man ./_build/man/deploid.1
google-chrome _build/html/index.html
evince _build/latex/DEploid.pdf 
```