### PR TITLE
Improve ibd

### DIFF
--- a/src/dEploidIO.cpp
+++ b/src/dEploidIO.cpp
@@ -260,6 +260,7 @@ void DEploidIO::removeFilesWithSameName(){
     strIbdExportProp = this->prefix_ + ".ibd.prop";
     strIbdExportLLK = this->prefix_ + ".ibd.llk";
     strIbdExportHap = this->prefix_ + ".ibd.hap";
+    strIbdExportProbs = this->prefix_ + ".ibd.probs";
 
     strExportVcf = this->prefix_ + ".vcf";
     if ( compressVcf() ){
@@ -275,6 +276,7 @@ void DEploidIO::removeFilesWithSameName(){
             remove(strIbdExportProp.c_str());
             remove(strIbdExportLLK.c_str());
             remove(strIbdExportHap.c_str());
+            remove(strIbdExportProbs.c_str());
         }
         remove(strExportLLK.c_str());
         remove(strExportHap.c_str());

--- a/src/dEploidIO.cpp
+++ b/src/dEploidIO.cpp
@@ -126,7 +126,7 @@ void DEploidIO::init() {
     this->setScalingFactor(100.0);
     this->setParameterG(20.0);
     this->setParameterSigma(5.0);
-
+    this->setIBDSigma(15.0);
     this->setUseVcf(false);
     this->vcfReaderPtr_ = NULL;
     this->setDoExportVcf(false);
@@ -385,6 +385,8 @@ void DEploidIO::parse (){
             this->setParameterG(readNextInput<double>());
         } else if ( *argv_i == "-sigma" ) {
             this->setParameterSigma(readNextInput<double>());
+        } else if ( *argv_i == "-ibdSigma" ) {
+            this->setIBDSigma(readNextInput<double>());
         } else if ( *argv_i == "-recomb" ) {
             this->constRecombProb_ = readNextInput<double>();
             this->useConstRecomb_ = true;

--- a/src/dEploidIO.cpp
+++ b/src/dEploidIO.cpp
@@ -126,7 +126,7 @@ void DEploidIO::init() {
     this->setScalingFactor(100.0);
     this->setParameterG(20.0);
     this->setParameterSigma(5.0);
-    this->setIBDSigma(15.0);
+    this->setIBDSigma(20.0);
     this->setUseVcf(false);
     this->vcfReaderPtr_ = NULL;
     this->setDoExportVcf(false);

--- a/src/dEploidIO.hpp
+++ b/src/dEploidIO.hpp
@@ -311,6 +311,9 @@ class DEploidIO{
     double parameterSigma_;
     void setParameterSigma ( const double setTo ) { this->parameterSigma_ = setTo; }
     double parameterSigma() const { return this->parameterSigma_; }
+    double ibdSigma_;
+    void setIBDSigma ( const double setTo ){ this->ibdSigma_ = setTo; }
+    double ibdSigma() const {return this->ibdSigma_;}
 
     size_t nLoci() const { return this->nLoci_; }
     void setKstrain ( const size_t setTo ){ this->kStrain_ = setTo;}

--- a/src/dEploidIO.hpp
+++ b/src/dEploidIO.hpp
@@ -271,7 +271,7 @@ class DEploidIO{
 
     // log and export resutls
     void writeRecombProb ( Panel * panel );
-    void writeIBDpostProb(vector < vector <double> > & reshapedProbs);
+    void writeIBDpostProb(vector < vector <double> > & reshapedProbs, vector <string> header);
 
     void writeLLK (McmcSample * mcmcSample, bool useIBD = false);
     void writeProp (McmcSample * mcmcSample, bool useIBD = false);

--- a/src/dEploidIO.hpp
+++ b/src/dEploidIO.hpp
@@ -271,6 +271,8 @@ class DEploidIO{
 
     // log and export resutls
     void writeRecombProb ( Panel * panel );
+    void writeIBDpostProb(vector < vector <double> > & reshapedProbs);
+
     void writeLLK (McmcSample * mcmcSample, bool useIBD = false);
     void writeProp (McmcSample * mcmcSample, bool useIBD = false);
     void writeHap (McmcSample * mcmcSample, bool useIBD = false);

--- a/src/dEploidIO.hpp
+++ b/src/dEploidIO.hpp
@@ -272,6 +272,8 @@ class DEploidIO{
     // log and export resutls
     void writeRecombProb ( Panel * panel );
     void writeIBDpostProb(vector < vector <double> > & reshapedProbs, vector <string> header);
+    vector <string> ibdProbsHeader;
+    vector <double> ibdProbsIntegrated;
 
     void writeLLK (McmcSample * mcmcSample, bool useIBD = false);
     void writeProp (McmcSample * mcmcSample, bool useIBD = false);

--- a/src/export/dEploidIOExport.cpp
+++ b/src/export/dEploidIOExport.cpp
@@ -121,7 +121,7 @@ void DEploidIO::writeLog ( ostream * writeTo ){
         (*writeTo) << "MCMC diagnostic:"<< "\n";
         (*writeTo) << setw(19) << " Accept_ratio: " << acceptRatio_ << "\n";
         (*writeTo) << setw(19) << " Max_llks: " << maxLLKs_ << "\n";
-        (*writeTo) << setw(19) << " Mean_theta_llks: " << meanThetallks_ << "\n";
+        (*writeTo) << setw(19) << " Final_theta_llks: " << meanThetallks_ << "\n";
         (*writeTo) << setw(19) << " Mean_llks: " << meanllks_ << "\n";
         (*writeTo) << setw(19) << " Stdv_llks: " << stdvllks_ << "\n";
         (*writeTo) << setw(19) << " DIC_by_Dtheta: " << dicByTheta_ << "\n";

--- a/src/export/dEploidIOExport.cpp
+++ b/src/export/dEploidIOExport.cpp
@@ -151,6 +151,7 @@ void DEploidIO::writeLog ( ostream * writeTo ){
             (*writeTo) << setw(14) << "Likelihood: "  << strIbdExportLLK  << "\n";
             (*writeTo) << setw(14) << "Proportions: " << strIbdExportProp << "\n";
             (*writeTo) << setw(14) << "Haplotypes: "  << strIbdExportHap  << "\n";
+            (*writeTo) << setw(14) << "State probs: "  << strIbdExportProbs  << "\n";
         }
     }
     (*writeTo) << "\n";
@@ -161,9 +162,6 @@ void DEploidIO::writeLog ( ostream * writeTo ){
     }
 
 }
-
-
-
 
 
 void DEploidIO::writeEventCount(){
@@ -227,3 +225,34 @@ void DEploidIO::writeEventCount(){
     ofstreamExportTmp.close();
 }
 
+
+void DEploidIO::writeIBDpostProb(vector < vector <double> > & reshapedProbs){
+    ofstreamExportTmp.open( strIbdExportProbs.c_str(), ios::out | ios::app | ios::binary );
+    //for (size_t fm_i = 0; fm_i < fm.size(); fm_i++){
+        //ofstreamExportTmp <<
+
+    //}
+
+    size_t siteIndex = 0;
+    for ( size_t chromIndex = 0; chromIndex < position_.size(); chromIndex++){
+        for ( size_t posI = 0; posI < position_[chromIndex].size(); posI++){
+            ofstreamExportTmp << chrom_[chromIndex] << "\t" << (int)position_[chromIndex][posI] << "\t";
+            //assert(stateIdx.size() == fm[siteIndex].size());
+            //size_t previousStateIdx = 0;
+            //double cumProb = 0;
+            for (size_t ij = 0; ij < reshapedProbs[siteIndex].size(); ij++){
+                //cumProb += fm[siteIndex][fm_ij];
+                //if (previousStateIdx != stateIdx[fm_ij]){
+                    //previousStateIdx++;
+                    ofstreamExportTmp << reshapedProbs[siteIndex][ij] << "\t";
+                    //cumProb = 0;
+                //}
+            }
+            ofstreamExportTmp << endl;
+
+            siteIndex++;
+        }
+    }
+    ofstreamExportTmp.close();
+    assert(siteIndex == nLoci());
+}

--- a/src/export/dEploidIOExport.cpp
+++ b/src/export/dEploidIOExport.cpp
@@ -151,7 +151,11 @@ void DEploidIO::writeLog ( ostream * writeTo ){
             (*writeTo) << setw(14) << "Likelihood: "  << strIbdExportLLK  << "\n";
             (*writeTo) << setw(14) << "Proportions: " << strIbdExportProp << "\n";
             (*writeTo) << setw(14) << "Haplotypes: "  << strIbdExportHap  << "\n";
-            (*writeTo) << setw(14) << "State probs: "  << strIbdExportProbs  << "\n";
+            (*writeTo) << setw(14) << "State probs: "  << strIbdExportProbs  << "\n\n";
+            (*writeTo) << " IBD probabilities:\n";
+            for ( size_t stateI = 0; stateI < this->ibdProbsHeader.size(); stateI++ ){
+                (*writeTo) << setw(14) << this->ibdProbsHeader[stateI] << ": " << this->ibdProbsIntegrated[stateI] << "\n";
+            }
         }
     }
     (*writeTo) << "\n";

--- a/src/export/dEploidIOExport.cpp
+++ b/src/export/dEploidIOExport.cpp
@@ -231,23 +231,35 @@ void DEploidIO::writeEventCount(){
 
 
 void DEploidIO::writeIBDpostProb(vector < vector <double> > & reshapedProbs, vector <string> header){
-    ofstreamExportTmp.open( strIbdExportProbs.c_str(), ios::out | ios::app | ios::binary );
-    ofstreamExportTmp << "CHROM" << "\t" << "POS" << "\t";
+    ostream * writeTo;
+    #ifdef UNITTEST
+        writeTo = &std::cout;
+    #endif
+
+    #ifndef UNITTEST
+        ofstreamExportTmp.open( strIbdExportProbs.c_str(), ios::out | ios::app | ios::binary );
+        writeTo = &ofstreamExportTmp;
+    #endif
+
+    (*writeTo) << "CHROM" << "\t" << "POS" << "\t";
     for (string tmp : header){
-        ofstreamExportTmp << tmp << ((tmp!=header[header.size()-1])?"\t":"\n");
+        (*writeTo) << tmp << ((tmp!=header[header.size()-1])?"\t":"\n");
     }
 
     size_t siteIndex = 0;
     for ( size_t chromIndex = 0; chromIndex < position_.size(); chromIndex++){
         for ( size_t posI = 0; posI < position_[chromIndex].size(); posI++){
-            ofstreamExportTmp << chrom_[chromIndex] << "\t" << (int)position_[chromIndex][posI] << "\t";
+            (*writeTo) << chrom_[chromIndex] << "\t" << (int)position_[chromIndex][posI] << "\t";
             for (size_t ij = 0; ij < reshapedProbs[siteIndex].size(); ij++){
-                ofstreamExportTmp << reshapedProbs[siteIndex][ij] << "\t";
+                (*writeTo) << reshapedProbs[siteIndex][ij] << "\t";
             }
-            ofstreamExportTmp << endl;
+            (*writeTo) << endl;
             siteIndex++;
         }
     }
-    ofstreamExportTmp.close();
     assert(siteIndex == nLoci());
+
+    #ifndef UNITTEST
+        ofstreamExportTmp.close();
+    #endif
 }

--- a/src/export/dEploidIOExport.cpp
+++ b/src/export/dEploidIOExport.cpp
@@ -107,7 +107,11 @@ void DEploidIO::writeLog ( ostream * writeTo ){
     (*writeTo) << setw(20) << " Miss copy prob: "   << this->missCopyProb_ << "\n";
     (*writeTo) << setw(20) << " Avrg Cent Morgan: " << this->averageCentimorganDistance_ << "\n";
     (*writeTo) << setw(20) << " G: "               << this->parameterG() << "\n";
+    if (this->useIBD()){
+    (*writeTo) << setw(20) << " IBD sigma: "               << this->ibdSigma() << "\n";
+    } else {
     (*writeTo) << setw(20) << " sigma: "               << this->parameterSigma() << "\n";
+    }
     (*writeTo) << setw(20) << " ScalingFactor: "    << this->scalingFactor() << "\n";
     if ( this->initialPropWasGiven() ){
         (*writeTo) << setw(20) << " Initial prob: " ;

--- a/src/export/dEploidIOExport.cpp
+++ b/src/export/dEploidIOExport.cpp
@@ -226,30 +226,21 @@ void DEploidIO::writeEventCount(){
 }
 
 
-void DEploidIO::writeIBDpostProb(vector < vector <double> > & reshapedProbs){
+void DEploidIO::writeIBDpostProb(vector < vector <double> > & reshapedProbs, vector <string> header){
     ofstreamExportTmp.open( strIbdExportProbs.c_str(), ios::out | ios::app | ios::binary );
-    //for (size_t fm_i = 0; fm_i < fm.size(); fm_i++){
-        //ofstreamExportTmp <<
-
-    //}
+    ofstreamExportTmp << "CHROM" << "\t" << "POS" << "\t";
+    for (string tmp : header){
+        ofstreamExportTmp << tmp << ((tmp!=header[header.size()-1])?"\t":"\n");
+    }
 
     size_t siteIndex = 0;
     for ( size_t chromIndex = 0; chromIndex < position_.size(); chromIndex++){
         for ( size_t posI = 0; posI < position_[chromIndex].size(); posI++){
             ofstreamExportTmp << chrom_[chromIndex] << "\t" << (int)position_[chromIndex][posI] << "\t";
-            //assert(stateIdx.size() == fm[siteIndex].size());
-            //size_t previousStateIdx = 0;
-            //double cumProb = 0;
             for (size_t ij = 0; ij < reshapedProbs[siteIndex].size(); ij++){
-                //cumProb += fm[siteIndex][fm_ij];
-                //if (previousStateIdx != stateIdx[fm_ij]){
-                    //previousStateIdx++;
-                    ofstreamExportTmp << reshapedProbs[siteIndex][ij] << "\t";
-                    //cumProb = 0;
-                //}
+                ofstreamExportTmp << reshapedProbs[siteIndex][ij] << "\t";
             }
             ofstreamExportTmp << endl;
-
             siteIndex++;
         }
     }

--- a/src/export/dEploidIOExportPosteriorProb.cpp
+++ b/src/export/dEploidIOExportPosteriorProb.cpp
@@ -83,7 +83,7 @@ void DEploidIO::writeLastSingleFwdProb( vector < vector <double> >& probabilitie
     ofstreamExportFwdProb.open( strExportFwdProb.c_str(), ios::out | ios::app | ios::binary );
 
     if ( chromIndex == 0 ){ // Print header
-        ofstreamExportFwdProb << "CHROM" << "\t" << "POS" << "\t";;
+        ofstreamExportFwdProb << "CHROM" << "\t" << "POS" << "\t";
         for ( size_t ii = 0; ii < probabilities[0].size(); ii++){
             if (this->doAllowInbreeding() == true){
                 if ( ii <= (panelSize - this->kStrain()) ){

--- a/src/ibd.hpp
+++ b/src/ibd.hpp
@@ -58,6 +58,7 @@ class IBDconfiguration{
   friend class TestHprior;
 #endif
   friend class Hprior;
+  friend class McmcMachinery;
     IBDconfiguration();
     ~IBDconfiguration();
 

--- a/src/mcmc.cpp
+++ b/src/mcmc.cpp
@@ -338,7 +338,8 @@ void McmcMachinery::runMcmcChain( bool showProgress, bool useIBD, bool notInR ){
 
     if ( useIBD == true ){
         vector < vector <double> > reshapedProbs = this->reshapeFm(fm, hprior.stateIdx);
-        this->dEploidIO_->writeIBDpostProb(reshapedProbs);
+        //vector <string> header = ;
+        this->dEploidIO_->writeIBDpostProb(reshapedProbs, getIBDprobsHeader());
         clog << "Proportion update acceptance rate: "<<acceptUpdate / (this->kStrain()*1.0*this->maxIteration_)<<endl;
         this->dEploidIO_->initialProp = averageProportion(this->mcmcSample_->proportion);
         this->dEploidIO_->setInitialPropWasGiven(true);
@@ -352,6 +353,22 @@ void McmcMachinery::runMcmcChain( bool showProgress, bool useIBD, bool notInR ){
     dout << "###########################################"<< endl;
     dout << "#            MCMC RUN finished            #"<< endl;
     dout << "###########################################"<< endl;
+}
+
+
+vector <string> McmcMachinery::getIBDprobsHeader(){
+    vector <string> ret;
+    for (size_t i = 0; i < hprior.ibdConfig.states.size(); i++){
+        string tmp;
+        for (size_t j = 0; j < hprior.ibdConfig.states[i].size(); j++){
+            stringstream tmp_ss;
+            tmp_ss << hprior.ibdConfig.states[i][j];
+            tmp += tmp_ss.str() + ((j < (hprior.ibdConfig.states[i].size()-1)) ? "-":"");
+        }
+        cout <<tmp<< endl;
+        ret.push_back(tmp);
+    }
+    return ret;
 }
 
 
@@ -468,21 +485,9 @@ vector <size_t> McmcMachinery::findWhichIsSomething(vector <size_t> tmpOp, size_
 
 
 void McmcMachinery::makeIbdTransProbs(){
-    size_t nPattern = hprior.nPattern();
-    for (size_t i = 0; i < hprior.ibdConfig.states.size(); i++){
-        for (size_t j = 0; j < hprior.ibdConfig.states[i].size(); j++){
-            cout << hprior.ibdConfig.states[i][j]<<"-";
-        }
-        cout << endl;
-
-    }
-    cout << "nPattern"<<nPattern << endl;
-    size_t nState = hprior.nState();
-    cout << "nState"<<nState << endl;
     assert(ibdTransProbs.size() == 0);
-
-    for ( size_t i = 0; i < nPattern; i++ ){
-        vector <double> transProbRow(nState);
+    for ( size_t i = 0; i < hprior.nPattern(); i++ ){
+        vector <double> transProbRow(hprior.nState());
         vector <size_t> wi = findWhichIsSomething(hprior.stateIdx, i);
         for (size_t wii : wi){
             transProbRow[wii] = 1;

--- a/src/mcmc.cpp
+++ b/src/mcmc.cpp
@@ -56,7 +56,7 @@ McmcMachinery::McmcMachinery(DEploidIO* dEploidIO, McmcSample *mcmcSample, Rando
         this->calcMaxIteration( dEploidIO_->nMcmcSample_ , dEploidIO_->mcmcMachineryRate_, dEploidIO_->mcmcBurn_ );
     }
     this->MN_LOG_TITRE = 0.0;
-    this->SD_LOG_TITRE = this->dEploidIO_->parameterSigma();
+    this->SD_LOG_TITRE = (useIBD == true) ? this->dEploidIO_->ibdSigma() : this->dEploidIO_->parameterSigma();
     this->PROP_SCALE = 40.0;
 
     stdNorm_ = new StandNormalRandomSample(this->seed_);

--- a/src/mcmc.hpp
+++ b/src/mcmc.hpp
@@ -207,9 +207,9 @@ class McmcMachinery {
     void ibdUpdateHaplotypesFromPrior();
     void ibdUpdateProportionGivenHap(vector <double> &llkAtAllSites);
     void computeAndUpdateTheta();
-    vector < vector <double> > reshapeFm(vector < vector <double> > &fm, vector <size_t> stateIdx);
+    vector < vector <double> > reshapeFm(vector <size_t> stateIdx);
     vector <string> getIBDprobsHeader();
-    vector <double> getIBDprobsIntegrated();
+    vector <double> getIBDprobsIntegrated(vector < vector <double> > &prob);
 
   /* Moves */
     void updateProportion();

--- a/src/mcmc.hpp
+++ b/src/mcmc.hpp
@@ -209,6 +209,7 @@ class McmcMachinery {
     void computeAndUpdateTheta();
     vector < vector <double> > reshapeFm(vector < vector <double> > &fm, vector <size_t> stateIdx);
     vector <string> getIBDprobsHeader();
+    vector <double> getIBDprobsIntegrated();
 
   /* Moves */
     void updateProportion();

--- a/src/mcmc.hpp
+++ b/src/mcmc.hpp
@@ -190,13 +190,13 @@ class McmcMachinery {
     vector <double> computeLlkAtAllSites(double err = 0.01);
     vector <double> averageProportion(vector < vector <double> > &proportion );
 
-    void initializeIbdEssentials();
+    void ibdInitializeEssentials();
     void makeLlkSurf(vector <double> altCount,
                      vector <double> refCount,
                      double scalingConst = 100.0,
                      double err = 0.01,
                      size_t gridSize=99);
-    void sampleMcmcEventIbdStep();
+    void ibdSampleMcmcEventStep();
     void makeIbdTransProbs();
     void initializePropIBD();
     void ibdBuildPathProbabilities(vector <double> statePrior);
@@ -207,6 +207,7 @@ class McmcMachinery {
     void ibdUpdateHaplotypesFromPrior();
     void ibdUpdateProportionGivenHap(vector <double> &llkAtAllSites);
     void computeAndUpdateTheta();
+    vector < vector <double> > reshapeFm(vector < vector <double> > &fm, vector <size_t> stateIdx);
 
   /* Moves */
     void updateProportion();

--- a/src/mcmc.hpp
+++ b/src/mcmc.hpp
@@ -208,6 +208,7 @@ class McmcMachinery {
     void ibdUpdateProportionGivenHap(vector <double> &llkAtAllSites);
     void computeAndUpdateTheta();
     vector < vector <double> > reshapeFm(vector < vector <double> > &fm, vector <size_t> stateIdx);
+    vector <string> getIBDprobsHeader();
 
   /* Moves */
     void updateProportion();

--- a/src/mcmc.hpp
+++ b/src/mcmc.hpp
@@ -94,6 +94,7 @@ class McmcMachinery {
   /* Variables */
     DEploidIO* dEploidIO_;
     Panel* panel_;
+    IBDrecombProbs ibdRecombProbs;
     size_t kStrain_;
     void setKstrain ( const size_t setTo ){ this->kStrain_ = setTo;}
     size_t kStrain() const { return this->kStrain_;}
@@ -198,9 +199,13 @@ class McmcMachinery {
     void sampleMcmcEventIbdStep();
     void makeIbdTransProbs();
     void initializePropIBD();
+    void ibdBuildPathProbabilities(vector <double> statePrior);
+    void ibdSamplePath(vector <double> statePrior);
     void computeUniqueEffectiveKCount();
     void updateFmAtSiteI(vector <double> & prior,
                          vector <double> & llk);
+    void ibdUpdateHaplotypesFromPrior();
+    void ibdUpdateProportionGivenHap(vector <double> &llkAtAllSites);
     void computeAndUpdateTheta();
 
   /* Moves */

--- a/src/panel.cpp
+++ b/src/panel.cpp
@@ -185,6 +185,30 @@ void Panel::updatePanelWithHaps(size_t inbreedingPanelSizeSetTo, size_t excluded
 }
 
 
+void IBDrecombProbs::computeRecombProbs( double averageCentimorganDistance, double G, bool useConstRecomb, double constRecombProb ){
+    assert(pRec_.size() == 0 );
+    assert(pNoRec_.size() == 0 );
+    double averageMorganDistance = averageCentimorganDistance * 100;
+    double geneticDistance;
+    double rho;
+    for ( size_t i = 0; i < this->position_.size(); i++){
+        for ( size_t j = 1; j < this->position_[i].size(); j++){
+            geneticDistance = (double)(this->position_[i][j] - this->position_[i][j-1])/averageMorganDistance ;
+            //rho = geneticDistance * 2 * Ne;
+            rho = geneticDistance * G;
+            double pRecTmp = ( useConstRecomb ) ? constRecombProb : 1.0 - exp(-rho);
+            this->pRec_.push_back( pRecTmp );
+            double pNoRecTmp = 1.0 - pRecTmp;
+            this->pNoRec_.push_back( pNoRecTmp );
+        }
+        this->pRec_.push_back(1.0);
+        this->pNoRec_.push_back(0.0);
+    }
+    assert(pRec_.size() == this->nLoci_ );
+    assert(pNoRec_.size() == this->nLoci_ );
+}
+
+
 
 //vector<vector<double>> outtrans(out[0].size(),
                                     //vector<double>(out.size()));

--- a/src/panel.hpp
+++ b/src/panel.hpp
@@ -89,4 +89,22 @@ class InitialHaplotypes: public Panel{
     ~InitialHaplotypes(){}
 };
 
+
+class IBDrecombProbs: public VariantIndex{
+ friend class McmcMachinery;
+  private:
+    vector < double > pRec_;
+    vector < double > pNoRec_; // = 1.0 - pRec;
+
+    void computeRecombProbs( double averageCentimorganDistance, double Ne, bool useConstRecomb, double constRecombProb );
+
+  public:
+    IBDrecombProbs():VariantIndex(){};
+    IBDrecombProbs(vector < vector < int> > position, size_t nLoci){
+        this->position_ = position;
+        this->nLoci_ = nLoci;
+    }
+    ~IBDrecombProbs(){}
+};
+
 #endif

--- a/src/variantIndex.hpp
+++ b/src/variantIndex.hpp
@@ -47,6 +47,7 @@ class VariantIndex {
  friend class TxtReader;
  friend class ExcludeMarker;
  friend class Panel;
+ friend class IBDrecombProbs;
  friend class VcfReader;
 
   private:

--- a/tests/unittest/test_mcmc.cpp
+++ b/tests/unittest/test_mcmc.cpp
@@ -106,6 +106,12 @@ class TestMcmcMachinery: public CppUnit::TestCase {
         dEploidIO_->altCount_ = vector<double> ({100, 10, 6});
         dEploidIO_->refCount_ = vector<double> ({9, 10, 106});
         dEploidIO_->plaf_ = vector<double> ({0.1, .4, .4});
+        vector < vector <int> > testPosition;
+        testPosition.push_back(vector<int> ({200, 3000}));
+        testPosition.push_back(vector<int> ({300}));
+        dEploidIO_->position_ = testPosition;
+        dEploidIO_->nLoci_ = 3;
+        dEploidIO_->chrom_ = vector <string> ({"chrom1", "chrom2"});
         rg_ = new MersenneTwister(dEploidIO_->randomSeed());
         mcmcMachinery_ = new McmcMachinery(this->dEploidIO_, this->mcmcSample_, this->rg_ );
         mcmcMachineryIbd_ = new McmcMachinery(this->dEploidIO_, this->mcmcSampleIbd_, this->rg_, true);


### PR DESCRIPTION
1. Set default IBD sigma to 20
2. Compute recombination probabilities, instead of using constant 0.01, which can also be set to const using the flag -recomb
3. Integrate the IBD state probabilities
4. Export the IBD state probabilities.